### PR TITLE
add support for LUD-17 non-bech32 encoded LNURL

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ A Dart implementation of lnurl to decode bech32 lnurl strings. Currently support
 
 ## Features
 * ✅ Decode a bech32-encoded lnurl string.
+* ✅ Handles LUD-17 non-bech32 lnurl string (lnurlw, lnurlp, lnurlc, keyauth).
 * ✅ Make GET request to the decoded ln service and return the response.
+
 
 
 Learn more about the lnurl spec here: https://github.com/btcontract/lnurl-rfc

--- a/lib/dart_lnurl.dart
+++ b/lib/dart_lnurl.dart
@@ -13,23 +13,20 @@ export 'src/success_action.dart';
 export 'src/bech32.dart';
 
 Uri decodeUri(String encodedUrl) {
-  late final Uri decodedUri;
+  Uri decodedUri;
 
   /// The URL doesn't have to be encoded at all as per LUD-17: Protocol schemes and raw (non bech32-encoded) URLs.
   /// https://github.com/lnurl/luds/blob/luds/17.md
   /// Handle non bech32-encoded LNURL
   final lud17prefixes = ['lnurlw', 'lnurlc', 'lnurlp', 'keyauth'];
-  final urifromstring = Uri.parse(encodedUrl);
-  if (lud17prefixes.contains(urifromstring.scheme)) {
+  decodedUri = Uri.parse(encodedUrl);
+  if (lud17prefixes.contains(decodedUri.scheme)) {
     /// If the non-bech32 LNURL is a Tor address, the port has to be http instead of https for the clearnet LNURL so check if the host ends with '.onion' or '.onion.'
-    final protocol = urifromstring.host.endsWith('onion.') ||
-            urifromstring.host.endsWith('onion')
-        ? 'http'
-        : 'https';
-
-    /// Non-bech32 LNURL so just return a string starting with http or https (LUD-17 compatibility) instead of the lud17 prefix
-    decodedUri =
-        Uri.parse(encodedUrl.replaceFirst(urifromstring.scheme, protocol));
+    decodedUri = decodedUri.replace(
+        scheme: decodedUri.host.endsWith('onion') ||
+                decodedUri.host.endsWith('onion.')
+            ? 'http'
+            : 'https');
   } else {
     /// Try to parse the input as a lnUrl. Will throw an error if it fails.
     final lnUrl = findLnUrl(encodedUrl);

--- a/lib/dart_lnurl.dart
+++ b/lib/dart_lnurl.dart
@@ -24,8 +24,8 @@ Uri decodeUri(String encodedUrl) {
     /// If the non-bech32 LNURL is a Tor address, the port has to be http instead of https for the clearnet LNURL so check if the host ends with '.onion' or '.onion.'
     final protocol = urifromstring.host.endsWith('onion.') ||
             urifromstring.host.endsWith('onion')
-        ? 'http://'
-        : 'https://';
+        ? 'http'
+        : 'https';
 
     /// Non-bech32 LNURL so just return a string starting with http or https (LUD-17 compatibility) instead of the lud17 prefix
     decodedUri =

--- a/lib/dart_lnurl.dart
+++ b/lib/dart_lnurl.dart
@@ -65,6 +65,18 @@ Future<LNURLParseResult> getParams(String encodedUrl) async {
     /// Parse the response body to json
     Map<String, dynamic> parsedJson = json.decode(res.body);
 
+    if (parsedJson['status'] == 'ERROR') {
+      return LNURLParseResult(
+        error: LNURLErrorResponse.fromJson({
+          ...parsedJson,
+          ...{
+            'domain': decodedUri.host,
+            'url': decodedUri.toString(),
+          }
+        }),
+      );
+    }
+
     /// If it contains a callback then add the domain as a key
     if (parsedJson['callback'] != null) {
       parsedJson['domain'] = Uri.parse(parsedJson['callback']).host;

--- a/lib/dart_lnurl.dart
+++ b/lib/dart_lnurl.dart
@@ -16,20 +16,16 @@ Uri decodeUri(String encodedUrl) {
   /// The URL can possibily be already decoded as per LUD-17: Protocol schemes and raw (non bech32-encoded) URLs.
   /// https://github.com/lnurl/luds/blob/luds/17.md
   /// Handle already decoded LNURL if they start with defined prefixes
-  var lud17prefixes = ['lnurlw://', 'lnurlc://', 'lnurlp://', 'keyauth://'];
+  final lud17prefixes = ['lnurlw', 'lnurlc', 'lnurlp', 'keyauth'];
+  
+  /// If the decoded LNURL is a Tor address, the port has to be http instead of https for the clearnet LNURL so check the .onion in URL also
+  final urifromstring = Uri.parse(encodedUrl);
+  final protocol = urifromstring.host.endsWith('onion.') || urifromstring.host.endsWith('onion') ? 'http://' : 'https://';
   late final Uri decodedUri;
 
-  /// If the decoded LNURL is a Tor address, the port has to be http instead of https for the clearnet LNURL so check the .onion in URL also
-  var protocol = (encodedUrl.contains('.onion') && !encodedUrl.contains('.onion.')) ? 'http://' : 'https://';
-  var urlprefix = "";
-  for (var prefix in lud17prefixes){
-     if (encodedUrl.startsWith(prefix)) {
-        urlprefix = prefix;
-     }
-  }
-  if (encodedUrl.startsWith(urlprefix)) {
-    /// Already decoded LNURL so just return a string starting with http or https (LUD-17 compatibility)
-    decodedUri = Uri.parse(encodedUrl.replaceFirst(urlprefix, protocol));
+  if (lud17prefixes.contains(urifromstring.scheme)) {
+    /// Already decoded LNURL so just return a string starting with http or https (LUD-17 compatibility) instead of the lud17 prefix
+    decodedUri = Uri.parse(encodedUrl.replaceFirst(urifromstring.scheme, protocol));
   } else {
     /// Try to parse the input as a lnUrl. Will throw an error if it fails.
     final lnUrl = findLnUrl(encodedUrl);

--- a/lib/dart_lnurl.dart
+++ b/lib/dart_lnurl.dart
@@ -20,6 +20,11 @@ Uri decodeUri(String encodedUrl) {
   /// Handle non bech32-encoded LNURL
   final lud17prefixes = ['lnurlw', 'lnurlc', 'lnurlp', 'keyauth'];
   decodedUri = Uri.parse(encodedUrl);
+  for (final prefix in lud17prefixes) {
+    if (decodedUri.scheme.contains(prefix)) {
+      decodedUri = decodedUri.replace(scheme: prefix);
+    }
+  }
   if (lud17prefixes.contains(decodedUri.scheme)) {
     /// If the non-bech32 LNURL is a Tor address, the port has to be http instead of https for the clearnet LNURL so check if the host ends with '.onion' or '.onion.'
     decodedUri = decodedUri.replace(

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -60,14 +60,12 @@ class LNURLPayParams {
         callback = json['callback'],
         minSendable = json['minSendable'],
         maxSendable = json['maxSendable'],
-        metadata = json['metadata'],
-        decodedMetadata = json['decodedMetadata'];
+        metadata = json['metadata'];
   final String tag;
   final String callback;
   final int minSendable;
   final int maxSendable;
   final String metadata;
-  final List<List<String>> decodedMetadata;
 }
 
 /// A success action will be returned when making a call to the lnUrl callback url.

--- a/test/dart_lnurl_test.dart
+++ b/test/dart_lnurl_test.dart
@@ -5,6 +5,25 @@ import 'package:test/test.dart';
 import 'util.dart';
 
 void main() {
+  test('should handle lnurlw://', () async {
+    final url =
+        'lnurlw://lnbits.btcslovnik.cz/boltcards/api/v1/scan/wpyeilzhasqu8rgsmfqbv9?p=D13EFAAEC499E07F611B279BA3EE982C&c=DF6C74D375DF8300';
+    final res = await getParams(url);
+    expect(res.error?.reason, 'This link is already used.');
+  });
+
+  test('should handle lnurlp://', () async {
+    final url = 'lnurlp://lnbits.cz/lnurlp/357';
+    final res = await getParams(url);
+    expect(res.payParams?.tag, 'payRequest');
+  });
+
+  test('should handle lnurlp:// with additional non-related prefix', () async {
+    final url = 'enlnurlp://lnbits.cz/lnurlp/357';
+    final res = await getParams(url);
+    expect(res.payParams?.tag, 'payRequest');
+  });
+
   test('should match lnurl without lightning:', () {
     final lnurl =
         'lnurl1dp68gurn8ghj7mrww4exctt5dahkccn00qhxget8wfjk2um0veax2un09e3k7mf0w5lhz0t9xcekzv34vgcx2vfkvcurxwphvgcrwefjvgcnqwrpxqmkxven89skgvp3vs6nwvpjvy6njdfsx5ekgephvcurxdf5xcerwvecvyunsf32lqq';

--- a/test/dart_lnurl_test.dart
+++ b/test/dart_lnurl_test.dart
@@ -5,23 +5,171 @@ import 'package:test/test.dart';
 import 'util.dart';
 
 void main() {
-  test('should handle lnurlw://', () async {
+  test('should handle bolt card lnurlw:// ', () async {
     final url =
         'lnurlw://lnbits.btcslovnik.cz/boltcards/api/v1/scan/wpyeilzhasqu8rgsmfqbv9?p=D13EFAAEC499E07F611B279BA3EE982C&c=DF6C74D375DF8300';
-    final res = await getParams(url);
-    expect(res.error?.reason, 'This link is already used.');
+    final res = decodeUri(url);
+    expect(
+        res,
+        Uri.parse(
+            'https://lnbits.btcslovnik.cz/boltcards/api/v1/scan/wpyeilzhasqu8rgsmfqbv9?p=D13EFAAEC499E07F611B279BA3EE982C&c=DF6C74D375DF8300'));
+  });
+  test('should handle onion bolt card lnurlw:// ', () async {
+    final url =
+        'lnurlw://lnbits.btcslovnikxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.onion/boltcards/api/v1/scan/wpyeilzhasqu8rgsmfqbv9?p=D13EFAAEC499E07F611B279BA3EE982C&c=DF6C74D375DF8300';
+    final res = decodeUri(url);
+    expect(
+        res,
+        Uri.parse(
+            'http://lnbits.btcslovnikxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.onion/boltcards/api/v1/scan/wpyeilzhasqu8rgsmfqbv9?p=D13EFAAEC499E07F611B279BA3EE982C&c=DF6C74D375DF8300'));
+  });
+  test('should handle bolt card lnurlw:// with additional non-related prefix',
+      () async {
+    final url =
+        'enlnurlw://lnbits.btcslovnik.cz/boltcards/api/v1/scan/wpyeilzhasqu8rgsmfqbv9?p=D13EFAAEC499E07F611B279BA3EE982C&c=DF6C74D375DF8300';
+    final res = decodeUri(url);
+    expect(
+        res,
+        Uri.parse(
+            'https://lnbits.btcslovnik.cz/boltcards/api/v1/scan/wpyeilzhasqu8rgsmfqbv9?p=D13EFAAEC499E07F611B279BA3EE982C&c=DF6C74D375DF8300'));
+  });
+  test(
+      'should handle onion bolt card lnurlw:// with additional non-related prefix',
+      () async {
+    final url =
+        'enlnurlw://lnbits.btcslovnikxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.onion/boltcards/api/v1/scan/wpyeilzhasqu8rgsmfqbv9?p=D13EFAAEC499E07F611B279BA3EE982C&c=DF6C74D375DF8300';
+    final res = decodeUri(url);
+    expect(
+        res,
+        Uri.parse(
+            'http://lnbits.btcslovnikxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.onion/boltcards/api/v1/scan/wpyeilzhasqu8rgsmfqbv9?p=D13EFAAEC499E07F611B279BA3EE982C&c=DF6C74D375DF8300'));
+  });
+
+  test('should handle static lnurlw://', () async {
+    final url = 'lnurlw://lnbits.cz/lnurlw/357';
+    final res = decodeUri(url);
+    expect(res, Uri.parse('https://lnbits.cz/lnurlw/357'));
+  });
+
+  test('should handle static lnurlw:// with additional non-related prefix',
+      () async {
+    final url = 'enlnurlw://lnbits.cz/lnurlw/357';
+    final res = await decodeUri(url);
+    //expect(res.payParams?.tag, 'payRequest');
+    expect(res, Uri.parse('https://lnbits.cz/lnurlw/357'));
+  });
+  test('should handle static onion lnurlw://', () async {
+    final url =
+        'lnurlw://lnbitsxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.onion/lnurlw/357';
+    final res = decodeUri(url);
+    expect(
+        res,
+        Uri.parse(
+            'http://lnbitsxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.onion/lnurlw/357'));
+  });
+  test(
+      'should handle static onion lnurlw:// with additional non-related prefix',
+      () async {
+    final url =
+        'enlnurlw://lnbitsxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.onion/lnurlw/357';
+    final res = decodeUri(url);
+    expect(
+        res,
+        Uri.parse(
+            'http://lnbitsxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.onion/lnurlw/357'));
   });
 
   test('should handle lnurlp://', () async {
     final url = 'lnurlp://lnbits.cz/lnurlp/357';
-    final res = await getParams(url);
-    expect(res.payParams?.tag, 'payRequest');
+    final res = decodeUri(url);
+    expect(res, Uri.parse('https://lnbits.cz/lnurlp/357'));
   });
-
   test('should handle lnurlp:// with additional non-related prefix', () async {
     final url = 'enlnurlp://lnbits.cz/lnurlp/357';
-    final res = await getParams(url);
-    expect(res.payParams?.tag, 'payRequest');
+    final res = await decodeUri(url);
+    //expect(res.payParams?.tag, 'payRequest');
+    expect(res, Uri.parse('https://lnbits.cz/lnurlp/357'));
+  });
+  test('should handle onion lnurlp://', () async {
+    final url =
+        'lnurlp://lnbitsxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.onion/lnurlp/357';
+    final res = decodeUri(url);
+    expect(
+        res,
+        Uri.parse(
+            'http://lnbitsxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.onion/lnurlp/357'));
+  });
+  test('should handle onion lnurlp:// with additional non-related prefix',
+      () async {
+    final url =
+        'enlnurlp://lnbitsxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.onion/lnurlp/357';
+    final res = decodeUri(url);
+    expect(
+        res,
+        Uri.parse(
+            'http://lnbitsxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.onion/lnurlp/357'));
+  });
+
+  test('should handle lnurlc://', () async {
+    final url = 'lnurlc://lnbits.cz/lnurlc/357';
+    final res = decodeUri(url);
+    expect(res, Uri.parse('https://lnbits.cz/lnurlc/357'));
+  });
+  test('should handle lnurlc:// with additional non-related prefix', () async {
+    final url = 'enlnurlc://lnbits.cz/lnurlc/357';
+    final res = await decodeUri(url);
+    //expect(res.payParams?.tag, 'payRequest');
+    expect(res, Uri.parse('https://lnbits.cz/lnurlc/357'));
+  });
+  test('should handle onion lnurlc://', () async {
+    final url =
+        'lnurlc://lnbitsxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.onion/lnurlc/357';
+    final res = decodeUri(url);
+    expect(
+        res,
+        Uri.parse(
+            'http://lnbitsxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.onion/lnurlc/357'));
+  });
+  test('should handle onion lnurlc:// with additional non-related prefix',
+      () async {
+    final url =
+        'enlnurlc://lnbitsxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.onion/lnurlc/357';
+    final res = decodeUri(url);
+    expect(
+        res,
+        Uri.parse(
+            'http://lnbitsxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.onion/lnurlc/357'));
+  });
+
+  test('should handle keyauth://', () async {
+    final url = 'keyauth://lnbits.cz/keyauth/357';
+    final res = decodeUri(url);
+    expect(res, Uri.parse('https://lnbits.cz/keyauth/357'));
+  });
+  test('should handle keyauth:// with additional non-related prefix', () async {
+    final url = 'enkeyauth://lnbits.cz/keyauth/357';
+    final res = await decodeUri(url);
+    //expect(res.payParams?.tag, 'payRequest');
+    expect(res, Uri.parse('https://lnbits.cz/keyauth/357'));
+  });
+  test('should handle onion keyauth://', () async {
+    final url =
+        'keyauth://lnbitsxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.onion/keyauth/357';
+    final res = decodeUri(url);
+    expect(
+        res,
+        Uri.parse(
+            'http://lnbitsxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.onion/keyauth/357'));
+  });
+  test('should handle onion keyauth:// with additional non-related prefix',
+      () async {
+    final url =
+        'enkeyauth://lnbitsxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.onion/keyauth/357';
+    final res = decodeUri(url);
+    expect(
+        res,
+        Uri.parse(
+            'http://lnbitsxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.onion/keyauth/357'));
   });
 
   test('should match lnurl without lightning:', () {


### PR DESCRIPTION
If the LNURL is non-bech32 encoded, it requires checking all the prefixes from LUD-17 (not only 'lnurlw') and substitute them with either http (for .onion links) or https (for clearnet links)

As @iWarpBTC told me even the '.' after tld is possible, that's why this code needs to check both 'onion' and 'onion.'.

`final protocol = urifromstring.host.endsWith('onion.') ||
            urifromstring.host.endsWith('onion')
        ? 'http://'
        : 'https://';`