### PR TITLE
code refactoring, optimalisations, tests, isBech32 func, rename decodeUri to parseUri

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # dart_lnurl
 [![pub package](https://img.shields.io/badge/pub-0.0.1-blueviolet.svg)](https://pub.dev/packages/dart_lnurl)
 
-A Dart implementation of lnurl to decode and bech32 lnurl strings. Currently supports the following tags:
+A Dart implementation of lnurl to decode bech32 and parse non-bech32 lnurl strings. Currently supports the following tags:
 * withdrawRequest
 * payRequest
 * channelRequest

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # dart_lnurl
 [![pub package](https://img.shields.io/badge/pub-0.0.1-blueviolet.svg)](https://pub.dev/packages/dart_lnurl)
 
-A Dart implementation of lnurl to decode bech32 lnurl strings. Currently supports the following tags:
+A Dart implementation of lnurl to decode and bech32 lnurl strings. Currently supports the following tags:
 * withdrawRequest
 * payRequest
 * channelRequest
@@ -10,7 +10,7 @@ A Dart implementation of lnurl to decode bech32 lnurl strings. Currently support
 ## Features
 * ✅ Decode a bech32-encoded lnurl string.
 * ✅ Handles LUD-17 non-bech32 lnurl string (lnurlw, lnurlp, lnurlc, keyauth).
-* ✅ Make GET request to the decoded ln service and return the response.
+* ✅ Make GET request to the ln service and return the response.
 
 
 
@@ -18,8 +18,8 @@ Learn more about the lnurl spec here: https://github.com/btcontract/lnurl-rfc
 
 # API Reference
 
-`Future<LNURLParseResult> getParams(String encodedUrl)`
-Use this to parse an encoded bech32 lnurl string, call the decoded URI, and return the parsed response from the lnurl service. The `encodedUrl` can either have `lightning:` in it or not.
+`Future<LNURLParseResult> getParams(String url)`
+Use this to parse a lnurl string, call the (decoded if needed) URI, and return the parsed response from the lnurl service. The bech32-encoded `url` can either have `lightning:` in it or not and non-bech32 `url` can either have `lnurlw:`,`lnurlp:`,`lnurlc:` or `keyauth:`.
 
 `String decryptSuccessActionAesPayload({LNURLPaySuccessAction successAction, String preimage})`
 

--- a/lib/dart_lnurl.dart
+++ b/lib/dart_lnurl.dart
@@ -12,7 +12,7 @@ export 'src/types.dart';
 export 'src/success_action.dart';
 export 'src/bech32.dart';
 
-Uri parseLnurl(String input) {
+Uri parseLnUri(String input) {
   Uri parsedUri;
   //Handle the cases when Uri doesn't have to be bech32 encoded, as per LUD-17
   if (!isbech32(input)) {
@@ -40,7 +40,7 @@ Uri parseLnurl(String input) {
 ///
 /// Throws [ArgumentError] if the provided input is not a valid lnurl.
 Future<LNURLParseResult> getParams(String url) async {
-  final parsedUri = parseLnurl(url);
+  final parsedUri = parseLnUri(url);
   try {
     /// Call the lnurl to get a response
     final res = await http.get(parsedUri);

--- a/lib/dart_lnurl.dart
+++ b/lib/dart_lnurl.dart
@@ -15,11 +15,8 @@ export 'src/bech32.dart';
 Uri parseLnUri(String input) {
   Uri parsedUri;
   //Handle the cases when Uri doesn't have to be bech32 encoded, as per LUD-17
-  if (!isbech32(input)) {
-    /// Non-Bech32 encoded URL
-    final String lnUrl = findLnUrlNonBech32(input);
-    parsedUri = Uri.parse(lnUrl);
-  } else {
+
+  if (isbech32(input)) {
     /// Bech32 encoded URL
     /// Try to parse the input as a lnUrl. Will throw an error if it fails.
     final lnUrl = findLnUrl(input);
@@ -27,6 +24,10 @@ Uri parseLnUri(String input) {
     /// Decode the lnurl using bech32
     final bech32 = Bech32Codec().decode(lnUrl, lnUrl.length);
     parsedUri = Uri.parse(utf8.decode(fromWords(bech32.data)));
+  } else {
+    /// Non-Bech32 encoded URL
+    final String lnUrl = findLnUrlNonBech32(input);
+    parsedUri = Uri.parse(lnUrl);
   }
   return parsedUri;
 }

--- a/lib/dart_lnurl.dart
+++ b/lib/dart_lnurl.dart
@@ -14,10 +14,13 @@ export 'src/bech32.dart';
 
 Uri decodeUri(String encodedUrl) {
   Uri decodedUri;
+  //Handle the cases when Uri doesn't have to be bech32 encoded, as per LUD-17
   if (!isbech32(encodedUrl)) {
+    /// Non-Bech32 encoded URL
     final String lnUrl = findLnUrlNonBech32(encodedUrl);
     decodedUri = Uri.parse(lnUrl);
   } else {
+    /// Bech32 encoded URL
     /// Try to parse the input as a lnUrl. Will throw an error if it fails.
     final lnUrl = findLnUrl(encodedUrl);
 

--- a/lib/dart_lnurl.dart
+++ b/lib/dart_lnurl.dart
@@ -14,25 +14,9 @@ export 'src/bech32.dart';
 
 Uri decodeUri(String encodedUrl) {
   Uri decodedUri;
-
-  /// The URL doesn't have to be encoded at all as per LUD-17: Protocol schemes and raw (non bech32-encoded) URLs.
-  /// https://github.com/lnurl/luds/blob/luds/17.md
-  /// Handle non bech32-encoded LNURL
-  final lud17prefixes = ['lnurlw', 'lnurlp', 'keyauth', 'lnurlc'];
-  decodedUri = Uri.parse(encodedUrl);
-  for (final prefix in lud17prefixes) {
-    if (decodedUri.scheme.contains(prefix)) {
-      decodedUri = decodedUri.replace(scheme: prefix);
-      break;
-    }
-  }
-  if (lud17prefixes.contains(decodedUri.scheme)) {
-    /// If the non-bech32 LNURL is a Tor address, the port has to be http instead of https for the clearnet LNURL so check if the host ends with '.onion' or '.onion.'
-    decodedUri = decodedUri.replace(
-        scheme: decodedUri.host.endsWith('onion') ||
-                decodedUri.host.endsWith('onion.')
-            ? 'http'
-            : 'https');
+  if (!isbech32(encodedUrl)) {
+    final String lnUrl = findLnUrlNonBech32(encodedUrl);
+    decodedUri = Uri.parse(lnUrl);
   } else {
     /// Try to parse the input as a lnUrl. Will throw an error if it fails.
     final lnUrl = findLnUrl(encodedUrl);

--- a/lib/dart_lnurl.dart
+++ b/lib/dart_lnurl.dart
@@ -13,12 +13,12 @@ export 'src/success_action.dart';
 export 'src/bech32.dart';
 
 Uri parseLnurl(String input) {
-  Uri parsedUrl;
+  Uri parsedUri;
   //Handle the cases when Uri doesn't have to be bech32 encoded, as per LUD-17
   if (!isbech32(input)) {
     /// Non-Bech32 encoded URL
     final String lnUrl = findLnUrlNonBech32(input);
-    parsedUrl = Uri.parse(lnUrl);
+    parsedUri = Uri.parse(lnUrl);
   } else {
     /// Bech32 encoded URL
     /// Try to parse the input as a lnUrl. Will throw an error if it fails.
@@ -26,9 +26,9 @@ Uri parseLnurl(String input) {
 
     /// Decode the lnurl using bech32
     final bech32 = Bech32Codec().decode(lnUrl, lnUrl.length);
-    parsedUrl = Uri.parse(utf8.decode(fromWords(bech32.data)));
+    parsedUri = Uri.parse(utf8.decode(fromWords(bech32.data)));
   }
-  return parsedUrl;
+  return parsedUri;
 }
 
 /// Get params from a lnurl string. Possible types are:
@@ -40,10 +40,10 @@ Uri parseLnurl(String input) {
 ///
 /// Throws [ArgumentError] if the provided input is not a valid lnurl.
 Future<LNURLParseResult> getParams(String url) async {
-  final parsedUrl = parseLnurl(url);
+  final parsedUri = parseLnurl(url);
   try {
     /// Call the lnurl to get a response
-    final res = await http.get(parsedUrl);
+    final res = await http.get(parsedUri);
 
     /// If there's an error then throw it
     if (res.statusCode >= 300) {
@@ -58,8 +58,8 @@ Future<LNURLParseResult> getParams(String url) async {
         error: LNURLErrorResponse.fromJson({
           ...parsedJson,
           ...{
-            'domain': parsedUrl.host,
-            'url': parsedUrl.toString(),
+            'domain': parsedUri.host,
+            'url': parsedUri.toString(),
           }
         }),
       );
@@ -101,8 +101,8 @@ Future<LNURLParseResult> getParams(String url) async {
             error: LNURLErrorResponse.fromJson({
               ...parsedJson,
               ...{
-                'domain': parsedUrl.host,
-                'url': parsedUrl.toString(),
+                'domain': parsedUri.host,
+                'url': parsedUri.toString(),
               }
             }),
           );
@@ -114,9 +114,9 @@ Future<LNURLParseResult> getParams(String url) async {
     return LNURLParseResult(
       error: LNURLErrorResponse.fromJson({
         'status': 'ERROR',
-        'reason': '${parsedUrl.toString()} returned error: ${e.toString()}',
-        'url': parsedUrl.toString(),
-        'domain': parsedUrl.host,
+        'reason': '${parsedUri.toString()} returned error: ${e.toString()}',
+        'url': parsedUri.toString(),
+        'domain': parsedUri.host,
       }),
     );
   }

--- a/lib/dart_lnurl.dart
+++ b/lib/dart_lnurl.dart
@@ -18,11 +18,12 @@ Uri decodeUri(String encodedUrl) {
   /// The URL doesn't have to be encoded at all as per LUD-17: Protocol schemes and raw (non bech32-encoded) URLs.
   /// https://github.com/lnurl/luds/blob/luds/17.md
   /// Handle non bech32-encoded LNURL
-  final lud17prefixes = ['lnurlw', 'lnurlc', 'lnurlp', 'keyauth'];
+  final lud17prefixes = ['lnurlw', 'lnurlp', 'keyauth', 'lnurlc'];
   decodedUri = Uri.parse(encodedUrl);
   for (final prefix in lud17prefixes) {
     if (decodedUri.scheme.contains(prefix)) {
       decodedUri = decodedUri.replace(scheme: prefix);
+      break;
     }
   }
   if (lud17prefixes.contains(decodedUri.scheme)) {

--- a/lib/src/lnurl.dart
+++ b/lib/src/lnurl.dart
@@ -39,19 +39,23 @@ String findLnUrlNonBech32(String input) {
 }
 
 bool isbech32(String input) {
-  String bech32 = '';
-  final res = new RegExp(
+  final match = new RegExp(
     r',*?((lnurl)([0-9]{1,}[a-z0-9]+){1})',
   ).allMatches(input.toLowerCase());
-  if (res.length == 1) {
+  if (match.length == 1) {
+    print(match.first.group(0));
+    // get the lnurl string from the regex
+    String lnurlBech32 = match.first.group(0)!;
+    String lnurlDecoded = '';
     try {
-      bech32 = Bech32Codec()
-          .decode(res.first.group(0)!.toLowerCase(), res.first.group(0)!.length)
+      // try to decode lowercased bech32 and store it to
+      lnurlDecoded = Bech32Codec()
+          .decode(lnurlBech32.toLowerCase(), lnurlBech32.length)
           .toString();
     } catch (e) {
       throw ArgumentError('Error when decoding bech32 lnurl');
     }
-    if (!bech32.isEmpty) {
+    if (!lnurlDecoded.isNotEmpty) {
       return true;
     }
   }

--- a/lib/src/lnurl.dart
+++ b/lib/src/lnurl.dart
@@ -1,3 +1,5 @@
+import 'package:bech32/bech32.dart';
+
 /// Parse and return a given lnurl string if it's valid. Will remove
 /// `lightning:` from the beginning of it if present.
 String findLnUrl(String input) {
@@ -10,4 +12,48 @@ String findLnUrl(String input) {
   } else {
     throw ArgumentError('Not a valid lnurl string');
   }
+}
+
+String findLnUrlNonBech32(String input) {
+  /// The URL doesn't have to be encoded at all as per LUD-17: Protocol schemes and raw (non bech32-encoded) URLs.
+  /// https://github.com/lnurl/luds/blob/luds/17.md
+  /// Handle non bech32-encoded LNURL
+
+  final lud17prefixes = ['lnurlw', 'lnurlp', 'keyauth', 'lnurlc'];
+  Uri decodedUri = Uri.parse(input);
+  for (final prefix in lud17prefixes) {
+    if (decodedUri.scheme.contains(prefix)) {
+      decodedUri = decodedUri.replace(scheme: prefix);
+      break;
+    }
+  }
+  if (lud17prefixes.contains(decodedUri.scheme)) {
+    /// If the non-bech32 LNURL is a Tor address, the port has to be http instead of https for the clearnet LNURL so check if the host ends with '.onion' or '.onion.'
+    decodedUri = decodedUri.replace(
+        scheme: decodedUri.host.endsWith('onion') ||
+                decodedUri.host.endsWith('onion.')
+            ? 'http'
+            : 'https');
+  }
+  return decodedUri.toString();
+}
+
+bool isbech32(String input) {
+  String bech32 = '';
+  final res = new RegExp(
+    r',*?((lnurl)([0-9]{1,}[a-z0-9]+){1})',
+  ).allMatches(input.toLowerCase());
+  if (res.length == 1) {
+    try {
+      bech32 = Bech32Codec()
+          .decode(res.first.group(0)!.toLowerCase(), res.first.group(0)!.length)
+          .toString();
+    } catch (e) {
+      throw ArgumentError('Error when decoding bech32 lnurl');
+    }
+    if (!bech32.isEmpty) {
+      return true;
+    }
+  }
+  return false;
 }

--- a/lib/src/lnurl.dart
+++ b/lib/src/lnurl.dart
@@ -18,22 +18,22 @@ String findLnUrlNonBech32(String input) {
   /// Handle non bech32-encoded LNURL
 
   final lud17prefixes = ['lnurlw', 'lnurlp', 'keyauth', 'lnurlc'];
-  Uri decodedUri = Uri.parse(input);
+  Uri parsedUri = Uri.parse(input);
   for (final prefix in lud17prefixes) {
-    if (decodedUri.scheme.contains(prefix)) {
-      decodedUri = decodedUri.replace(scheme: prefix);
+    if (parsedUri.scheme.contains(prefix)) {
+      parsedUri = parsedUri.replace(scheme: prefix);
       break;
     }
   }
-  if (lud17prefixes.contains(decodedUri.scheme)) {
+  if (lud17prefixes.contains(parsedUri.scheme)) {
     /// If the non-bech32 LNURL is a Tor address, the port has to be http instead of https for the clearnet LNURL so check if the host ends with '.onion' or '.onion.'
-    decodedUri = decodedUri.replace(
-        scheme: decodedUri.host.endsWith('onion') ||
-                decodedUri.host.endsWith('onion.')
+    parsedUri = parsedUri.replace(
+        scheme: parsedUri.host.endsWith('onion') ||
+                parsedUri.host.endsWith('onion.')
             ? 'http'
             : 'https');
   }
-  return decodedUri.toString();
+  return parsedUri.toString();
 }
 
 bool isbech32(String input) {

--- a/lib/src/lnurl.dart
+++ b/lib/src/lnurl.dart
@@ -1,5 +1,3 @@
-import 'package:bech32/bech32.dart';
-
 /// Parse and return a given lnurl string if it's valid. Will remove
 /// `lightning:` from the beginning of it if present.
 String findLnUrl(String input) {
@@ -42,22 +40,5 @@ bool isbech32(String input) {
   final match = new RegExp(
     r',*?((lnurl)([0-9]{1,}[a-z0-9]+){1})',
   ).allMatches(input.toLowerCase());
-  if (match.length == 1) {
-    print(match.first.group(0));
-    // get the lnurl string from the regex
-    String lnurlBech32 = match.first.group(0)!;
-    String lnurlDecoded = '';
-    try {
-      // try to decode lowercased bech32 and store it to
-      lnurlDecoded = Bech32Codec()
-          .decode(lnurlBech32.toLowerCase(), lnurlBech32.length)
-          .toString();
-    } catch (e) {
-      throw ArgumentError('Error when decoding bech32 lnurl');
-    }
-    if (!lnurlDecoded.isNotEmpty) {
-      return true;
-    }
-  }
-  return false;
+  return match.length == 1 ? true : false;
 }

--- a/test/dart_lnurl_test.dart
+++ b/test/dart_lnurl_test.dart
@@ -8,7 +8,7 @@ void main() {
   test('should handle bolt card lnurlw:// ', () async {
     final url =
         'lnurlw://lnbits.btcslovnik.cz/boltcards/api/v1/scan/wpyeilzhasqu8rgsmfqbv9?p=D13EFAAEC499E07F611B279BA3EE982C&c=DF6C74D375DF8300';
-    final res = parseLnurl(url);
+    final res = parseLnUri(url);
     expect(
         res,
         Uri.parse(
@@ -17,7 +17,7 @@ void main() {
   test('should handle onion bolt card lnurlw:// ', () async {
     final url =
         'lnurlw://lnbits.btcslovnikxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.onion/boltcards/api/v1/scan/wpyeilzhasqu8rgsmfqbv9?p=D13EFAAEC499E07F611B279BA3EE982C&c=DF6C74D375DF8300';
-    final res = parseLnurl(url);
+    final res = parseLnUri(url);
     expect(
         res,
         Uri.parse(
@@ -27,7 +27,7 @@ void main() {
       () async {
     final url =
         'enlnurlw://lnbits.btcslovnik.cz/boltcards/api/v1/scan/wpyeilzhasqu8rgsmfqbv9?p=D13EFAAEC499E07F611B279BA3EE982C&c=DF6C74D375DF8300';
-    final res = parseLnurl(url);
+    final res = parseLnUri(url);
     expect(
         res,
         Uri.parse(
@@ -38,7 +38,7 @@ void main() {
       () async {
     final url =
         'enlnurlw://lnbits.btcslovnikxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.onion/boltcards/api/v1/scan/wpyeilzhasqu8rgsmfqbv9?p=D13EFAAEC499E07F611B279BA3EE982C&c=DF6C74D375DF8300';
-    final res = parseLnurl(url);
+    final res = parseLnUri(url);
     expect(
         res,
         Uri.parse(
@@ -47,21 +47,21 @@ void main() {
 
   test('should handle static lnurlw://', () async {
     final url = 'lnurlw://lnbits.cz/lnurlw/357';
-    final res = parseLnurl(url);
+    final res = parseLnUri(url);
     expect(res, Uri.parse('https://lnbits.cz/lnurlw/357'));
   });
 
   test('should handle static lnurlw:// with additional non-related prefix',
       () async {
     final url = 'enlnurlw://lnbits.cz/lnurlw/357';
-    final res = await parseLnurl(url);
+    final res = await parseLnUri(url);
     //expect(res.payParams?.tag, 'payRequest');
     expect(res, Uri.parse('https://lnbits.cz/lnurlw/357'));
   });
   test('should handle static onion lnurlw://', () async {
     final url =
         'lnurlw://lnbitsxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.onion/lnurlw/357';
-    final res = parseLnurl(url);
+    final res = parseLnUri(url);
     expect(
         res,
         Uri.parse(
@@ -72,7 +72,7 @@ void main() {
       () async {
     final url =
         'enlnurlw://lnbitsxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.onion/lnurlw/357';
-    final res = parseLnurl(url);
+    final res = parseLnUri(url);
     expect(
         res,
         Uri.parse(
@@ -81,19 +81,19 @@ void main() {
 
   test('should handle lnurlp://', () async {
     final url = 'lnurlp://lnbits.cz/lnurlp/357';
-    final res = parseLnurl(url);
+    final res = parseLnUri(url);
     expect(res, Uri.parse('https://lnbits.cz/lnurlp/357'));
   });
   test('should handle lnurlp:// with additional non-related prefix', () async {
     final url = 'enlnurlp://lnbits.cz/lnurlp/357';
-    final res = await parseLnurl(url);
+    final res = await parseLnUri(url);
     //expect(res.payParams?.tag, 'payRequest');
     expect(res, Uri.parse('https://lnbits.cz/lnurlp/357'));
   });
   test('should handle onion lnurlp://', () async {
     final url =
         'lnurlp://lnbitsxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.onion/lnurlp/357';
-    final res = parseLnurl(url);
+    final res = parseLnUri(url);
     expect(
         res,
         Uri.parse(
@@ -103,7 +103,7 @@ void main() {
       () async {
     final url =
         'enlnurlp://lnbitsxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.onion/lnurlp/357';
-    final res = parseLnurl(url);
+    final res = parseLnUri(url);
     expect(
         res,
         Uri.parse(
@@ -112,19 +112,19 @@ void main() {
 
   test('should handle lnurlc://', () async {
     final url = 'lnurlc://lnbits.cz/lnurlc/357';
-    final res = parseLnurl(url);
+    final res = parseLnUri(url);
     expect(res, Uri.parse('https://lnbits.cz/lnurlc/357'));
   });
   test('should handle lnurlc:// with additional non-related prefix', () async {
     final url = 'enlnurlc://lnbits.cz/lnurlc/357';
-    final res = await parseLnurl(url);
+    final res = await parseLnUri(url);
     //expect(res.payParams?.tag, 'payRequest');
     expect(res, Uri.parse('https://lnbits.cz/lnurlc/357'));
   });
   test('should handle onion lnurlc://', () async {
     final url =
         'lnurlc://lnbitsxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.onion/lnurlc/357';
-    final res = parseLnurl(url);
+    final res = parseLnUri(url);
     expect(
         res,
         Uri.parse(
@@ -134,7 +134,7 @@ void main() {
       () async {
     final url =
         'enlnurlc://lnbitsxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.onion/lnurlc/357';
-    final res = parseLnurl(url);
+    final res = parseLnUri(url);
     expect(
         res,
         Uri.parse(
@@ -143,19 +143,19 @@ void main() {
 
   test('should handle keyauth://', () async {
     final url = 'keyauth://lnbits.cz/keyauth/357';
-    final res = parseLnurl(url);
+    final res = parseLnUri(url);
     expect(res, Uri.parse('https://lnbits.cz/keyauth/357'));
   });
   test('should handle keyauth:// with additional non-related prefix', () async {
     final url = 'enkeyauth://lnbits.cz/keyauth/357';
-    final res = await parseLnurl(url);
+    final res = await parseLnUri(url);
     //expect(res.payParams?.tag, 'payRequest');
     expect(res, Uri.parse('https://lnbits.cz/keyauth/357'));
   });
   test('should handle onion keyauth://', () async {
     final url =
         'keyauth://lnbitsxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.onion/keyauth/357';
-    final res = parseLnurl(url);
+    final res = parseLnUri(url);
     expect(
         res,
         Uri.parse(
@@ -165,7 +165,7 @@ void main() {
       () async {
     final url =
         'enkeyauth://lnbitsxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.onion/keyauth/357';
-    final res = parseLnurl(url);
+    final res = parseLnUri(url);
     expect(
         res,
         Uri.parse(
@@ -213,7 +213,7 @@ void main() {
   test('should parse lnurl-pay', () async {
     final url =
         'lightning:LNURL1DP68GURN8GHJ7MRWW4EXCTNZD9NHXATW9EU8J730D3H82UNV94CXZ7FLWDJHXUMFDAHR6C3NXGCNGCEE8YEX2CFHXCCRYCNXXUENVEFHXQCR2EF5XS6R2D35XUERSEFC8YCKGDF5XAJNGCTX8PJRYVP4XDJNVD3CX3NRVEFCX4SSWRA86F';
-    final res = parseLnurl(url);
+    final res = parseLnUri(url);
     expect(res, isNotNull);
   });
 
@@ -221,7 +221,7 @@ void main() {
     final lnurl =
         'lnurl1dp68gurn8ghj7mrww4exctt5dahkccn00qhxget8wfjk2um0veax2un09e3k7mf0w5lhz0t9xcekzv34vgcx2vfkvcurxwphvgcrwefjvgcnqwrpxqmkxven89skgvp3vs6nwvpjvy6njdfsx5ekgephvcurxdf5xcerwvecvyunsf32lqq';
     expect(
-        parseLnurl(lnurl),
+        parseLnUri(lnurl),
         Uri.parse(
             'https://lnurl-toolbox.degreesofzero.com/u?q=e63a25b0e16f8387b07e2b108a07c339ad01d5702a595053dd7f835462738a98'));
   });
@@ -230,7 +230,7 @@ void main() {
     final lnurl =
         'lightning:lnurl1dp68gurn8ghj7mrww4exctt5dahkccn00qhxget8wfjk2um0veax2un09e3k7mf0w5lhz0t9xcekzv34vgcx2vfkvcurxwphvgcrwefjvgcnqwrpxqmkxven89skgvp3vs6nwvpjvy6njdfsx5ekgephvcurxdf5xcerwvecvyunsf32lqq';
     expect(
-        parseLnurl(lnurl),
+        parseLnUri(lnurl),
         Uri.parse(
             'https://lnurl-toolbox.degreesofzero.com/u?q=e63a25b0e16f8387b07e2b108a07c339ad01d5702a595053dd7f835462738a98'));
   });
@@ -239,7 +239,7 @@ void main() {
     final lnurl =
         'lightning:LNURL1DP68GURN8GHJ7MRWW4EXCTT5DAHKCCN00QHXGET8WFJK2UM0VEAX2UN09E3K7MF0W5LHZ0T9XCEKZV34VGCX2VFKVCURXWPHVGCRWEFJVGCNQWRPXQMKXVEN89SKGVP3VS6NWVPJVY6NJDFSX5EKGEPHVCURXDF5XCERWVECVYUNSF32LQQ';
     expect(
-        parseLnurl(lnurl),
+        parseLnUri(lnurl),
         Uri.parse(
             'https://lnurl-toolbox.degreesofzero.com/u?q=e63a25b0e16f8387b07e2b108a07c339ad01d5702a595053dd7f835462738a98'));
   });
@@ -248,7 +248,7 @@ void main() {
     final lnurl =
         'lightning:LNURL1DP68GURN8GHJ7MRWW4EXCTT5DAHKCCN00QHXGET8WFJK2UM0VEAX2UN09E3K7MF0W5LHZ0T9XCEKZV34VGCX2VFKVCURXWPHVGCRWEFJVGCNQWRPXQMKXVEN89SKGVP3VS6NWVPJVY6NJDFSX5EKGEPHVCURXDF5XCERWVECVYUNSF32LQQ';
     expect(
-        parseLnurl(lnurl),
+        parseLnUri(lnurl),
         Uri.parse(
             'https://lnurl-toolbox.degreesofzero.com/u?q=e63a25b0e16f8387b07e2b108a07c339ad01d5702a595053dd7f835462738a98'));
   });

--- a/test/dart_lnurl_test.dart
+++ b/test/dart_lnurl_test.dart
@@ -8,7 +8,7 @@ void main() {
   test('should handle bolt card lnurlw:// ', () async {
     final url =
         'lnurlw://lnbits.btcslovnik.cz/boltcards/api/v1/scan/wpyeilzhasqu8rgsmfqbv9?p=D13EFAAEC499E07F611B279BA3EE982C&c=DF6C74D375DF8300';
-    final res = decodeUri(url);
+    final res = parseLnurl(url);
     expect(
         res,
         Uri.parse(
@@ -17,7 +17,7 @@ void main() {
   test('should handle onion bolt card lnurlw:// ', () async {
     final url =
         'lnurlw://lnbits.btcslovnikxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.onion/boltcards/api/v1/scan/wpyeilzhasqu8rgsmfqbv9?p=D13EFAAEC499E07F611B279BA3EE982C&c=DF6C74D375DF8300';
-    final res = decodeUri(url);
+    final res = parseLnurl(url);
     expect(
         res,
         Uri.parse(
@@ -27,7 +27,7 @@ void main() {
       () async {
     final url =
         'enlnurlw://lnbits.btcslovnik.cz/boltcards/api/v1/scan/wpyeilzhasqu8rgsmfqbv9?p=D13EFAAEC499E07F611B279BA3EE982C&c=DF6C74D375DF8300';
-    final res = decodeUri(url);
+    final res = parseLnurl(url);
     expect(
         res,
         Uri.parse(
@@ -38,7 +38,7 @@ void main() {
       () async {
     final url =
         'enlnurlw://lnbits.btcslovnikxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.onion/boltcards/api/v1/scan/wpyeilzhasqu8rgsmfqbv9?p=D13EFAAEC499E07F611B279BA3EE982C&c=DF6C74D375DF8300';
-    final res = decodeUri(url);
+    final res = parseLnurl(url);
     expect(
         res,
         Uri.parse(
@@ -47,21 +47,21 @@ void main() {
 
   test('should handle static lnurlw://', () async {
     final url = 'lnurlw://lnbits.cz/lnurlw/357';
-    final res = decodeUri(url);
+    final res = parseLnurl(url);
     expect(res, Uri.parse('https://lnbits.cz/lnurlw/357'));
   });
 
   test('should handle static lnurlw:// with additional non-related prefix',
       () async {
     final url = 'enlnurlw://lnbits.cz/lnurlw/357';
-    final res = await decodeUri(url);
+    final res = await parseLnurl(url);
     //expect(res.payParams?.tag, 'payRequest');
     expect(res, Uri.parse('https://lnbits.cz/lnurlw/357'));
   });
   test('should handle static onion lnurlw://', () async {
     final url =
         'lnurlw://lnbitsxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.onion/lnurlw/357';
-    final res = decodeUri(url);
+    final res = parseLnurl(url);
     expect(
         res,
         Uri.parse(
@@ -72,7 +72,7 @@ void main() {
       () async {
     final url =
         'enlnurlw://lnbitsxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.onion/lnurlw/357';
-    final res = decodeUri(url);
+    final res = parseLnurl(url);
     expect(
         res,
         Uri.parse(
@@ -81,19 +81,19 @@ void main() {
 
   test('should handle lnurlp://', () async {
     final url = 'lnurlp://lnbits.cz/lnurlp/357';
-    final res = decodeUri(url);
+    final res = parseLnurl(url);
     expect(res, Uri.parse('https://lnbits.cz/lnurlp/357'));
   });
   test('should handle lnurlp:// with additional non-related prefix', () async {
     final url = 'enlnurlp://lnbits.cz/lnurlp/357';
-    final res = await decodeUri(url);
+    final res = await parseLnurl(url);
     //expect(res.payParams?.tag, 'payRequest');
     expect(res, Uri.parse('https://lnbits.cz/lnurlp/357'));
   });
   test('should handle onion lnurlp://', () async {
     final url =
         'lnurlp://lnbitsxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.onion/lnurlp/357';
-    final res = decodeUri(url);
+    final res = parseLnurl(url);
     expect(
         res,
         Uri.parse(
@@ -103,7 +103,7 @@ void main() {
       () async {
     final url =
         'enlnurlp://lnbitsxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.onion/lnurlp/357';
-    final res = decodeUri(url);
+    final res = parseLnurl(url);
     expect(
         res,
         Uri.parse(
@@ -112,19 +112,19 @@ void main() {
 
   test('should handle lnurlc://', () async {
     final url = 'lnurlc://lnbits.cz/lnurlc/357';
-    final res = decodeUri(url);
+    final res = parseLnurl(url);
     expect(res, Uri.parse('https://lnbits.cz/lnurlc/357'));
   });
   test('should handle lnurlc:// with additional non-related prefix', () async {
     final url = 'enlnurlc://lnbits.cz/lnurlc/357';
-    final res = await decodeUri(url);
+    final res = await parseLnurl(url);
     //expect(res.payParams?.tag, 'payRequest');
     expect(res, Uri.parse('https://lnbits.cz/lnurlc/357'));
   });
   test('should handle onion lnurlc://', () async {
     final url =
         'lnurlc://lnbitsxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.onion/lnurlc/357';
-    final res = decodeUri(url);
+    final res = parseLnurl(url);
     expect(
         res,
         Uri.parse(
@@ -134,7 +134,7 @@ void main() {
       () async {
     final url =
         'enlnurlc://lnbitsxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.onion/lnurlc/357';
-    final res = decodeUri(url);
+    final res = parseLnurl(url);
     expect(
         res,
         Uri.parse(
@@ -143,19 +143,19 @@ void main() {
 
   test('should handle keyauth://', () async {
     final url = 'keyauth://lnbits.cz/keyauth/357';
-    final res = decodeUri(url);
+    final res = parseLnurl(url);
     expect(res, Uri.parse('https://lnbits.cz/keyauth/357'));
   });
   test('should handle keyauth:// with additional non-related prefix', () async {
     final url = 'enkeyauth://lnbits.cz/keyauth/357';
-    final res = await decodeUri(url);
+    final res = await parseLnurl(url);
     //expect(res.payParams?.tag, 'payRequest');
     expect(res, Uri.parse('https://lnbits.cz/keyauth/357'));
   });
   test('should handle onion keyauth://', () async {
     final url =
         'keyauth://lnbitsxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.onion/keyauth/357';
-    final res = decodeUri(url);
+    final res = parseLnurl(url);
     expect(
         res,
         Uri.parse(
@@ -165,7 +165,7 @@ void main() {
       () async {
     final url =
         'enkeyauth://lnbitsxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.onion/keyauth/357';
-    final res = decodeUri(url);
+    final res = parseLnurl(url);
     expect(
         res,
         Uri.parse(
@@ -210,10 +210,46 @@ void main() {
     expect(decrypted, plainText);
   });
 
-  test('should decode lnurl-pay', () async {
+  test('should parse lnurl-pay', () async {
     final url =
         'lightning:LNURL1DP68GURN8GHJ7MRWW4EXCTNZD9NHXATW9EU8J730D3H82UNV94CXZ7FLWDJHXUMFDAHR6C3NXGCNGCEE8YEX2CFHXCCRYCNXXUENVEFHXQCR2EF5XS6R2D35XUERSEFC8YCKGDF5XAJNGCTX8PJRYVP4XDJNVD3CX3NRVEFCX4SSWRA86F';
-    final res = decodeUri(url);
+    final res = parseLnurl(url);
     expect(res, isNotNull);
+  });
+
+  test('should parse lnurl without lightning:', () {
+    final lnurl =
+        'lnurl1dp68gurn8ghj7mrww4exctt5dahkccn00qhxget8wfjk2um0veax2un09e3k7mf0w5lhz0t9xcekzv34vgcx2vfkvcurxwphvgcrwefjvgcnqwrpxqmkxven89skgvp3vs6nwvpjvy6njdfsx5ekgephvcurxdf5xcerwvecvyunsf32lqq';
+    expect(
+        parseLnurl(lnurl),
+        Uri.parse(
+            'https://lnurl-toolbox.degreesofzero.com/u?q=e63a25b0e16f8387b07e2b108a07c339ad01d5702a595053dd7f835462738a98'));
+  });
+
+  test('should parse lnurl with lightning:', () {
+    final lnurl =
+        'lightning:lnurl1dp68gurn8ghj7mrww4exctt5dahkccn00qhxget8wfjk2um0veax2un09e3k7mf0w5lhz0t9xcekzv34vgcx2vfkvcurxwphvgcrwefjvgcnqwrpxqmkxven89skgvp3vs6nwvpjvy6njdfsx5ekgephvcurxdf5xcerwvecvyunsf32lqq';
+    expect(
+        parseLnurl(lnurl),
+        Uri.parse(
+            'https://lnurl-toolbox.degreesofzero.com/u?q=e63a25b0e16f8387b07e2b108a07c339ad01d5702a595053dd7f835462738a98'));
+  });
+
+  test('should parse LNURL without lightning:', () {
+    final lnurl =
+        'lightning:LNURL1DP68GURN8GHJ7MRWW4EXCTT5DAHKCCN00QHXGET8WFJK2UM0VEAX2UN09E3K7MF0W5LHZ0T9XCEKZV34VGCX2VFKVCURXWPHVGCRWEFJVGCNQWRPXQMKXVEN89SKGVP3VS6NWVPJVY6NJDFSX5EKGEPHVCURXDF5XCERWVECVYUNSF32LQQ';
+    expect(
+        parseLnurl(lnurl),
+        Uri.parse(
+            'https://lnurl-toolbox.degreesofzero.com/u?q=e63a25b0e16f8387b07e2b108a07c339ad01d5702a595053dd7f835462738a98'));
+  });
+
+  test('should parse LNURL with lightning:', () {
+    final lnurl =
+        'lightning:LNURL1DP68GURN8GHJ7MRWW4EXCTT5DAHKCCN00QHXGET8WFJK2UM0VEAX2UN09E3K7MF0W5LHZ0T9XCEKZV34VGCX2VFKVCURXWPHVGCRWEFJVGCNQWRPXQMKXVEN89SKGVP3VS6NWVPJVY6NJDFSX5EKGEPHVCURXDF5XCERWVECVYUNSF32LQQ';
+    expect(
+        parseLnurl(lnurl),
+        Uri.parse(
+            'https://lnurl-toolbox.degreesofzero.com/u?q=e63a25b0e16f8387b07e2b108a07c339ad01d5702a595053dd7f835462738a98'));
   });
 }

--- a/test/dart_lnurl_test.dart
+++ b/test/dart_lnurl_test.dart
@@ -50,6 +50,71 @@ void main() {
     final res = parseLnUri(url);
     expect(res, Uri.parse('https://lnbits.cz/lnurlw/357'));
   });
+  test('should handle static lnurlw with lightning:', () async {
+    final url =
+        'lightning:LNURL1DP68GURN8GHJ7MRWVF5HGUEWVF6XXURVV96XY7FWVDAZ7AMFW35XGUNPWUHKZURF9AMRZTMVDE6HYMP0GF8Y5V63FFX9WKT5FDTHXD3CVF9XG42DW9VSN09NNG';
+    final res = parseLnUri(url);
+    expect(
+        res,
+        Uri.parse(
+            'https://lnbits.btcplatby.cz/withdraw/api/v1/lnurl/BNJ3QJLWYtKWs68bJdUMqY'));
+  });
+
+  test(
+      'should handle static lnurlw with lightning: and with additional non-related prefix',
+      () async {
+    final url =
+        'enlightning:LNURL1DP68GURN8GHJ7MRWVF5HGUEWVF6XXURVV96XY7FWVDAZ7AMFW35XGUNPWUHKZURF9AMRZTMVDE6HYMP0GF8Y5V63FFX9WKT5FDTHXD3CVF9XG42DW9VSN09NNG';
+    final res = parseLnUri(url);
+    expect(
+        res,
+        Uri.parse(
+            'https://lnbits.btcplatby.cz/withdraw/api/v1/lnurl/BNJ3QJLWYtKWs68bJdUMqY'));
+  });
+
+  test('should handle static onion lnurlw with lightning:', () async {
+    final url =
+        'lightning:LNURL1DP68GUP69UHKCMNZD968XTNZW33HQMRPW338J7RC0PU8S7RC0PU8S7RC0PU8S7RC0PU8S7RC0PU8S7RC0PU8S7RC0PU8S7RC0PU8S7RC0PU8S7RC0PU8S7RC9EHKU6T0DCHHW6T5DPJ8YCTH9ASHQ6F0WCCJ7MRWW4EXCT6ZFE9RX522F3T4JAZT2AENVWRZFFJ92NT3TYXRL2DG';
+    final res = parseLnUri(url);
+    expect(
+        res,
+        Uri.parse(
+            'http://lnbits.btcplatbyxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.onion/withdraw/api/v1/lnurl/BNJ3QJLWYtKWs68bJdUMqY'));
+  });
+
+  test(
+      'should handle static onion lnurlw with lightning:  and with additional non-related prefix',
+      () async {
+    final url =
+        'enlightning:LNURL1DP68GUP69UHKCMNZD968XTNZW33HQMRPW338J7RC0PU8S7RC0PU8S7RC0PU8S7RC0PU8S7RC0PU8S7RC0PU8S7RC0PU8S7RC0PU8S7RC0PU8S7RC0PU8S7RC9EHKU6T0DCHHW6T5DPJ8YCTH9ASHQ6F0WCCJ7MRWW4EXCT6ZFE9RX522F3T4JAZT2AENVWRZFFJ92NT3TYXRL2DG';
+    final res = parseLnUri(url);
+    expect(
+        res,
+        Uri.parse(
+            'http://lnbits.btcplatbyxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.onion/withdraw/api/v1/lnurl/BNJ3QJLWYtKWs68bJdUMqY'));
+  });
+
+  test('should handle static onion lowercase lnurlw with lightning:', () async {
+    final url =
+        'lightning:lnurl1dp68gup69uhkcmnzd968xtnzw33hqmrpw338j7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc9ehku6t0dchhw6t5dpj8ycth9ashq6f0wccj7mrww4exct6zfe9rx522f3t4jazt2aenvwrzffj92nt3tyxrl2dg';
+    final res = parseLnUri(url);
+    expect(
+        res,
+        Uri.parse(
+            'http://lnbits.btcplatbyxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.onion/withdraw/api/v1/lnurl/BNJ3QJLWYtKWs68bJdUMqY'));
+  });
+
+  test(
+      'should handle static onion lowercase lnurlw with lightning and other non-related prefix:',
+      () async {
+    final url =
+        'enlightning:lnurl1dp68gup69uhkcmnzd968xtnzw33hqmrpw338j7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc9ehku6t0dchhw6t5dpj8ycth9ashq6f0wccj7mrww4exct6zfe9rx522f3t4jazt2aenvwrzffj92nt3tyxrl2dg';
+    final res = parseLnUri(url);
+    expect(
+        res,
+        Uri.parse(
+            'http://lnbits.btcplatbyxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.onion/withdraw/api/v1/lnurl/BNJ3QJLWYtKWs68bJdUMqY'));
+  });
 
   test('should handle static lnurlw:// with additional non-related prefix',
       () async {


### PR DESCRIPTION
Add 'break' to not check all the prefixes

Basically rewrite the dart_lnurl.dart and hide the handing of non-bech32 lnurls into lnurl.dart for better reading of the code

Adding some tests to verify it handles most of the cases

Add small isBech32() boolean function that tells if the lnurl is bech32 encoded or not (which helps a lot to make code more readable)

Rename the decodeUri to parseUri to make it more clear that it handles both encoded and non encoded lnurls